### PR TITLE
HomeAssistant HomeKit Controller compatibility fix

### DIFF
--- a/packages/homebridge-haier-ac/src/haier.ts
+++ b/packages/homebridge-haier-ac/src/haier.ts
@@ -53,7 +53,7 @@ export class HapHaierAC {
     info
       .setCharacteristic(this._api.hap.Characteristic.Manufacturer, 'Haier')
       .setCharacteristic(this._api.hap.Characteristic.Model, 'AirCond')
-      .setCharacteristic(this._api.hap.Characteristic.SerialNumber, 'Undefined');
+      .setCharacteristic(this._api.hap.Characteristic.SerialNumber, config.mac);
 
     // Active
     thermostatService


### PR DESCRIPTION
As described here: https://github.com/home-assistant/core/issues/50811

haier-ac-remote does not provide a unique identifier for HomeAssistant to be able to distinquish between devices. This causes it to only create a single AC entity. Which is fine if you only have 1 AC, but does not quite work if you have more, like I do (I have 2 units).

The proposed fix should solve this issue.