### PR TITLE
feat(homebridge): HeaterCooler representation + modern Homebridge 2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,28 @@
         "dbus2js": "bin/dbus2js.js"
       }
     },
+    "node_modules/@homebridge/hap-nodejs": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.9.tgz",
+      "integrity": "sha512-+VBg84jVVM9sm4s4u5l64qLl07Skuei9Z7bF13J1T5zWOb3Fq6hzZMUJfLK6zUk6EAuY/3bf9TgV+eLT7YE5Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@homebridge/ciao": "^1.3.10",
+        "@homebridge/dbus-native": "^0.7.7",
+        "bonjour-hap": "^3.10.4",
+        "debug": "^4.4.3",
+        "fast-srp-hap": "^2.0.4",
+        "futoin-hkdf": "^1.5.3",
+        "node-persist": "^0.0.12",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": "^22 || ^24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -172,6 +194,96 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@matter/general": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.6.tgz",
+      "integrity": "sha512-PiSly47lwR+31sMWZTxT9eVgibfC2PB3FflTwxhVDzektrNNYT4wh9+5abTNhQmszs/VnXixbyo64HSz+LQS8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^2.2.0"
+      }
+    },
+    "node_modules/@matter/main": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.6.tgz",
+      "integrity": "sha512-RBXVLxJGEd3IUZ63QrHPUpb7o1amErvs2MoK3bJpnUXYNqXAuN2IHLTYZ04j4yrdMHJlyGSDxdIYr5rN6zXqSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
+      },
+      "optionalDependencies": {
+        "@matter/nodejs": "0.17.6"
+      }
+    },
+    "node_modules/@matter/model": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.6.tgz",
+      "integrity": "sha512-ECf6r0zTq6FS6IA4ov8qtSu36iyO1oxEJT06RFYX/SVDOyfhgzRjQDSIsVtW4UwTMht8kSVnDJE9EAO0qY37YA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.6"
+      }
+    },
+    "node_modules/@matter/node": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.6.tgz",
+      "integrity": "sha512-qtkh3/hz+73Wh7kY+Jz9HogrnpqjIMreYaY//VEMb9Jl/tY1A+3RFa7PDIY51LK2m+gWy3boXu/3kdYEvn00ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
+      }
+    },
+    "node_modules/@matter/nodejs": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.6.tgz",
+      "integrity": "sha512-tvn2wLMgjd1YVKr/kAkKq50WU+8mUeoDVCPIyO6aXJMsy0GTOc8/vC3Lu3ZIUD1IwMiOgn67xnqBVozpp+ZjTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@matter/general": "0.17.6",
+        "@matter/node": "0.17.6",
+        "@matter/protocol": "0.17.6",
+        "@matter/types": "0.17.6"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+      }
+    },
+    "node_modules/@matter/protocol": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.6.tgz",
+      "integrity": "sha512-p3oc8v2RKKbV4RkkjKemDpzheNHFMQJnbxpij2yKpxsXYIXpYnwtexnvLxDpZCJPsd9Jv3igSxxURBEUexHmBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6",
+        "@matter/types": "0.17.6"
+      }
+    },
+    "node_modules/@matter/types": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.6.tgz",
+      "integrity": "sha512-zYCWx+om6hQR6s6CHniWJMaOsqzTNDKcxUoU0QI8ZgF39SCtIeIb+qOzNigoAtKKZzhVdo9B5IsbEbYY4PhO3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.6",
+        "@matter/model": "0.17.6"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -189,6 +301,35 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1112,10 +1253,11 @@
       }
     },
     "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1127,14 +1269,27 @@
         "node": ">=18"
       }
     },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/debug": {
@@ -1252,9 +1407,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1292,43 +1447,15 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/haier-ac-remote": {
       "resolved": "packages/haier-ac-remote",
       "link": true
-    },
-    "node_modules/hap-nodejs": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.14.3.tgz",
-      "integrity": "sha512-kl7z4r84WN/bjQmO2OA8+RefPVtPQw6k2hs7/q1+ROghE9G6C5f/yNenR7/yYnZLfXMXQfY4yLiYY5uLCKXT1w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@homebridge/ciao": "^1.3.6",
-        "@homebridge/dbus-native": "^0.7.4",
-        "bonjour-hap": "^3.10.1",
-        "debug": "^4.4.3",
-        "fast-srp-hap": "^2.0.4",
-        "futoin-hkdf": "^1.5.3",
-        "node-persist": "^0.0.12",
-        "source-map-support": "^0.5.21",
-        "tslib": "^2.8.1",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": "^18 || ^20 || ^22 || ^24"
-      }
-    },
-    "node_modules/hap-nodejs/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true,
-      "license": "Unlicense"
     },
     "node_modules/hexy": {
       "version": "0.4.0",
@@ -1343,119 +1470,31 @@
       }
     },
     "node_modules/homebridge": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.11.4.tgz",
-      "integrity": "sha512-8rffC5N+vG/AaZwWwKB30m4pDauFVM1zRauY4mPk5dTpRv8+4QLC8dG7arLe6mW+i5UM8Q5lUeNyBdSjrIukkA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.2.1.tgz",
+      "integrity": "sha512-U6VBjxMC4DoVx/v9D0FBTh6eZ2Vkis7DePY4vQlgxWxRNJ9G+Ul31tBy/rj7+k1oVhlihnWRwukWLRQ1ZO+52w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "4.1.2",
-        "commander": "13.1.0",
-        "fs-extra": "11.3.4",
-        "hap-nodejs": "0.14.3",
+        "@homebridge/hap-nodejs": "2.1.9",
+        "@matter/main": "0.17.6",
+        "chalk": "5.6.2",
+        "commander": "15.0.0",
+        "fs-extra": "11.3.6",
         "qrcode-terminal": "0.12.0",
-        "semver": "7.7.4",
+        "semver": "7.8.5",
         "source-map-support": "0.5.21"
       },
       "bin": {
-        "homebridge": "bin/homebridge"
+        "homebridge": "bin/homebridge.js"
       },
       "engines": {
-        "node": "^18.15.0 || ^20.7.0 || ^22 || ^24"
+        "node": "^22 || ^24"
       }
     },
     "node_modules/homebridge-haier-ac": {
       "resolved": "packages/homebridge-haier-ac",
       "link": true
-    },
-    "node_modules/homebridge/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/homebridge/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/homebridge/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/homebridge/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/homebridge/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/homebridge/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/homebridge/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -1913,19 +1952,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/map-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
@@ -1944,12 +1970,13 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -2163,10 +2190,25 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -2178,12 +2220,35 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2204,15 +2269,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/split": {
@@ -2266,8 +2322,9 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -2356,6 +2413,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/typescript": {
       "version": "7.0.2",
@@ -2679,7 +2743,7 @@
         "haier-ac-remote": "^0.2.0"
       },
       "devDependencies": {
-        "homebridge": "^1.3.0"
+        "homebridge": "^2.2.1"
       },
       "engines": {
         "homebridge": ">=1.3.0",

--- a/packages/homebridge-haier-ac/README.md
+++ b/packages/homebridge-haier-ac/README.md
@@ -15,7 +15,7 @@ Homebridge plugin for controlling Haier Air Conditioner
      - `ip` - IP address of air conditioner
      - `mac` - MAC address of air conditioner in format `0001325476AC`
    - Optional parameters:
-     - `treatAutoHeatAs` - `fan`/`smart` (default `fan`). Select mode binded to 'auto' in homekit
+     - `treatAutoHeatAs` - `fan`/`smart` (default `fan`). Which AC mode HomeKit's `AUTO` maps to
 
 ## config.json
 
@@ -31,12 +31,26 @@ Homebridge plugin for controlling Haier Air Conditioner
 ]
 ```
 
+## How it appears in HomeKit
+
+The AC is exposed as a native **Heater Cooler** accessory (plus a small switch):
+
+| HomeKit control               | Maps to                                     |
+| ----------------------------- | ------------------------------------------- |
+| On / Off (`Active`)           | Power                                       |
+| Mode `AUTO` / `HEAT` / `COOL` | `treatAutoHeatAs` (smart/fan) / heat / cool |
+| Current temperature           | Sensor reading from the AC                  |
+| Target temperature            | Cooling/heating threshold, 16–30 °C         |
+| Fan speed                     | `0%` = auto, then low / medium / high       |
+| Swing                         | Vertical louver                             |
+| **Health** switch             | Ionizer / health mode                       |
+
+Changes made with the physical remote are pushed back to HomeKit automatically.
+
+> Fan speed uses `0%` to mean **automatic** (on/off is a separate `Active` control on
+> a Heater Cooler, so `0%` is a valid "auto" speed rather than "off").
+
 ## Features
 
-- Turning AC on and off
-- Getting and setting target temperature
-- Getting current temperature
-- Getting and setting mode
-- Getting and setting swing mode
-- Getting and setting wind level
-- Reacting to changes made by using AC's remote
+- Power on/off, mode, target/current temperature, fan speed, swing, health
+- Reacts to changes made with the AC's own remote

--- a/packages/homebridge-haier-ac/package.json
+++ b/packages/homebridge-haier-ac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-haier-ac",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Haier AC plugin for Homebridge",
   "author": "Andrew Lavrentev <andrew.lavrentev@gmail.com>",
   "license": "MIT",
@@ -27,13 +27,13 @@
     "typecheck": "../../node_modules/.bin/tsc --noEmit --project ./tsconfig.json"
   },
   "engines": {
-    "node": ">=12.0.0",
-    "homebridge": ">=1.3.0"
+    "node": ">=18.0.0",
+    "homebridge": ">=1.6.0"
   },
   "dependencies": {
     "haier-ac-remote": "^0.2.0"
   },
   "devDependencies": {
-    "homebridge": "^1.3.0"
+    "homebridge": "^2.2.1"
   }
 }

--- a/packages/homebridge-haier-ac/src/haier.ts
+++ b/packages/homebridge-haier-ac/src/haier.ts
@@ -1,251 +1,268 @@
 import { FanSpeed, HaierAC, Limits, Mode } from 'haier-ac-remote';
-import { API, Logger, AccessoryConfig } from 'homebridge';
+import {
+  AccessoryConfig,
+  AccessoryPlugin,
+  API,
+  CharacteristicValue,
+  Logging,
+  Service,
+} from 'homebridge';
 
-export class HapHaierAC {
-  protected readonly _api: API;
-  services: any[];
-  on = 1;
-  _device: HaierAC;
-  log: Logger;
-  autoMode: Mode;
-  name: string;
+export class HapHaierAC implements AccessoryPlugin {
+  protected readonly api: API;
+  protected readonly log: Logging;
+  protected readonly device: HaierAC;
+  protected readonly name: string;
+  protected readonly autoMode: Mode;
 
-  constructor(log: Logger, baseConfig: AccessoryConfig, api: API) {
-    const config = Object.assign(
-      {
-        timeout: 3000,
-        treatAutoHeatAs: 'fan',
-      },
-      baseConfig,
-    );
+  protected readonly informationService: Service;
+  protected readonly heaterCooler: Service;
+  protected readonly healthSwitch: Service;
 
-    if (!config.ip) throw new Error('Your must provide IP address of the AC');
-    if (!config.mac) throw new Error('Your must provide mac of the AC');
+  constructor(log: Logging, baseConfig: AccessoryConfig, api: API) {
+    const config = Object.assign({ timeout: 3000, treatAutoHeatAs: 'fan' }, baseConfig);
 
-    const info = new api.hap.Service.AccessoryInformation();
-    const thermostatService = new api.hap.Service.Thermostat();
-    const fanService = new api.hap.Service.Fanv2('Fan speed');
-    const lightService = new api.hap.Service.Lightbulb('Health');
+    if (!config.ip) throw new Error('You must provide the IP address of the AC');
+    if (!config.mac) throw new Error('You must provide the MAC of the AC');
 
+    this.api = api;
     this.log = log;
-    this._api = api;
     this.name = config.name;
-    this.services = [info, thermostatService, fanService, lightService];
-    this.autoMode = config.treatAutoHeatAs === 'fan' ? Mode.FAN : Mode.SMART;
-    this._device = new HaierAC({
-      ip: config.ip,
-      mac: config.mac,
-      timeout: config.timeout,
-    });
+    this.autoMode = config.treatAutoHeatAs === 'smart' ? Mode.SMART : Mode.FAN;
+    this.device = new HaierAC({ ip: config.ip, mac: config.mac, timeout: config.timeout });
 
-    // Device info
-    info
-      .setCharacteristic(this._api.hap.Characteristic.Manufacturer, 'Haier')
-      .setCharacteristic(this._api.hap.Characteristic.Model, 'AirCond')
-      .setCharacteristic(this._api.hap.Characteristic.SerialNumber, config.mac);
+    const { Characteristic } = api.hap;
 
-    // Active
-    thermostatService
-      .getCharacteristic(this._api.hap.Characteristic.TargetHeatingCoolingState)
-      .onGet(this.getTargetHeatingCoolingState)
-      .onSet(this.setTargetHeatingCoolingState);
+    this.informationService = new api.hap.Service.AccessoryInformation()
+      .setCharacteristic(Characteristic.Manufacturer, 'Haier')
+      .setCharacteristic(Characteristic.Model, 'AirCond')
+      .setCharacteristic(Characteristic.SerialNumber, config.mac);
 
-    thermostatService
-      .getCharacteristic(this._api.hap.Characteristic.CurrentTemperature)
+    // Air conditioner -> native HeaterCooler service
+    this.heaterCooler = new api.hap.Service.HeaterCooler(this.name);
+
+    this.heaterCooler
+      .getCharacteristic(Characteristic.Active)
+      .onGet(this.getActive)
+      .onSet(this.setActive);
+
+    this.heaterCooler
+      .getCharacteristic(Characteristic.CurrentHeaterCoolerState)
+      .onGet(this.getCurrentHeaterCoolerState);
+
+    this.heaterCooler
+      .getCharacteristic(Characteristic.TargetHeaterCoolerState)
+      .setProps({
+        validValues: [
+          Characteristic.TargetHeaterCoolerState.AUTO,
+          Characteristic.TargetHeaterCoolerState.HEAT,
+          Characteristic.TargetHeaterCoolerState.COOL,
+        ],
+      })
+      .onGet(this.getTargetHeaterCoolerState)
+      .onSet(this.setTargetHeaterCoolerState);
+
+    this.heaterCooler
+      .getCharacteristic(Characteristic.CurrentTemperature)
       .onGet(this.getCurrentTemperature);
 
-    thermostatService
-      .getCharacteristic(this._api.hap.Characteristic.TargetTemperature)
-      .setProps({
-        minValue: 16,
-        maxValue: 30,
-        minStep: 1,
-      })
+    const tempProps = { minValue: 16, maxValue: 30, minStep: 1 };
+    this.heaterCooler
+      .getCharacteristic(Characteristic.CoolingThresholdTemperature)
+      .setProps(tempProps)
+      .onGet(this.getTargetTemperature)
+      .onSet(this.setTargetTemperature);
+    this.heaterCooler
+      .getCharacteristic(Characteristic.HeatingThresholdTemperature)
+      .setProps(tempProps)
       .onGet(this.getTargetTemperature)
       .onSet(this.setTargetTemperature);
 
-    fanService
-      .getCharacteristic(this._api.hap.Characteristic.SwingMode)
-      .onGet(this.getSwingMode)
-      .onSet(this.setSwingMode);
-
-    fanService
-      .getCharacteristic(this._api.hap.Characteristic.RotationSpeed)
-      .setProps({
-        minValue: 0,
-        maxValue: 3,
-        minStep: 1,
-      })
+    this.heaterCooler
+      .getCharacteristic(Characteristic.RotationSpeed)
+      .setProps({ minValue: 0, maxValue: 100, minStep: 1 })
       .onGet(this.getRotationSpeed)
       .onSet(this.setRotationSpeed);
 
-    lightService
-      .getCharacteristic(this._api.hap.Characteristic.On)
-      .onGet(this.getHealthMode)
-      .onSet(this.setHealthMode);
+    this.heaterCooler
+      .getCharacteristic(Characteristic.SwingMode)
+      .onGet(this.getSwingMode)
+      .onSet(this.setSwingMode);
+
+    // Health / ionizer -> honest Switch (was a Lightbulb)
+    this.healthSwitch = new api.hap.Service.Switch(`${this.name} Health`, 'health');
+    this.healthSwitch
+      .getCharacteristic(Characteristic.On)
+      .onGet(this.getHealth)
+      .onSet(this.setHealth);
+
+    // Reflect changes made from the physical remote back into HomeKit.
+    this.device.state$.subscribe(this.pushState);
   }
 
-  getServices() {
-    return this.services;
+  getServices(): Service[] {
+    return [this.informationService, this.heaterCooler, this.healthSwitch];
   }
 
-  /**
-   * TargetHeatingCoolingState: [Function] {
-   *   UUID: '00000033-0000-1000-8000-0026BB765291',
-   *   OFF: 0,
-   *   HEAT: 1,
-   *   COOL: 2,
-   *   AUTO: 3
-   * },
-   */
-  getTargetHeatingCoolingState = async () => {
-    const { power, mode } = this._device.state$.value;
+  protected pushState = () => {
+    const { Characteristic } = this.api.hap;
+    this.heaterCooler.updateCharacteristic(Characteristic.Active, this.getActive());
+    this.heaterCooler.updateCharacteristic(
+      Characteristic.CurrentHeaterCoolerState,
+      this.getCurrentHeaterCoolerState(),
+    );
+    this.heaterCooler.updateCharacteristic(
+      Characteristic.TargetHeaterCoolerState,
+      this.getTargetHeaterCoolerState(),
+    );
+    this.heaterCooler.updateCharacteristic(
+      Characteristic.CurrentTemperature,
+      this.getCurrentTemperature(),
+    );
+    this.heaterCooler.updateCharacteristic(
+      Characteristic.CoolingThresholdTemperature,
+      this.getTargetTemperature(),
+    );
+    this.heaterCooler.updateCharacteristic(
+      Characteristic.HeatingThresholdTemperature,
+      this.getTargetTemperature(),
+    );
+    this.heaterCooler.updateCharacteristic(Characteristic.RotationSpeed, this.getRotationSpeed());
+    this.heaterCooler.updateCharacteristic(Characteristic.SwingMode, this.getSwingMode());
+    this.healthSwitch.updateCharacteristic(Characteristic.On, this.getHealth());
+  };
 
-    if (!power) {
-      return this._api.hap.Characteristic.TargetHeatingCoolingState.OFF;
-    }
+  // ---- getters (read synchronously from the reactive state) ----
 
-    switch (mode) {
+  protected getActive = (): CharacteristicValue => {
+    const { Active } = this.api.hap.Characteristic;
+    return this.device.state$.value.power ? Active.ACTIVE : Active.INACTIVE;
+  };
+
+  protected getCurrentHeaterCoolerState = (): CharacteristicValue => {
+    const { CurrentHeaterCoolerState } = this.api.hap.Characteristic;
+    const { power, mode } = this.device.state$.value;
+
+    if (!power) return CurrentHeaterCoolerState.INACTIVE;
+    if (mode === Mode.HEAT) return CurrentHeaterCoolerState.HEATING;
+    if (mode === Mode.COOL) return CurrentHeaterCoolerState.COOLING;
+
+    return CurrentHeaterCoolerState.IDLE;
+  };
+
+  protected getTargetHeaterCoolerState = (): CharacteristicValue => {
+    const { TargetHeaterCoolerState } = this.api.hap.Characteristic;
+
+    switch (this.device.state$.value.mode) {
       case Mode.HEAT:
-        return this._api.hap.Characteristic.TargetHeatingCoolingState.HEAT;
+        return TargetHeaterCoolerState.HEAT;
       case Mode.COOL:
-        return this._api.hap.Characteristic.TargetHeatingCoolingState.COOL;
+        return TargetHeaterCoolerState.COOL;
       default:
-        return this._api.hap.Characteristic.TargetHeatingCoolingState.AUTO;
+        return TargetHeaterCoolerState.AUTO;
     }
   };
 
-  setTargetHeatingCoolingState = async (state: any) => {
-    const { mode, power } = this._device.state$.value;
-    try {
-      if (state === this._api.hap.Characteristic.TargetHeatingCoolingState.OFF) {
-        if (power) {
-          await this._device.off();
-        }
-
-        return;
-      }
-
-      switch (state) {
-        case this._api.hap.Characteristic.TargetHeatingCoolingState.HEAT:
-          if (mode !== Mode.HEAT) {
-            await this._device.changeState({
-              mode: Mode.HEAT,
-            });
-          }
-
-          return;
-        case this._api.hap.Characteristic.TargetHeatingCoolingState.COOL:
-          if (mode !== Mode.COOL) {
-            await this._device.changeState({
-              mode: Mode.COOL,
-            });
-          }
-
-          return;
-        default:
-          if (mode !== this.autoMode || !power) {
-            await this._device.changeState({
-              mode: this.autoMode,
-            });
-          }
-
-          return;
-      }
-    } catch (error) {
-      this.log.error(String(error));
-    }
+  protected getCurrentTemperature = (): CharacteristicValue => {
+    return this.device.state$.value.currentTemperature;
   };
 
-  getCurrentTemperature = async () => {
-    return this._device.state$.value.currentTemperature;
+  protected getTargetTemperature = (): CharacteristicValue => {
+    return this.device.state$.value.targetTemperature;
   };
 
-  getHealthMode = async () => {
-    return +this._device.state$.value.health;
-  };
-
-  setHealthMode = async (state: any) => {
-    try {
-      await this._device.changeState({
-        health: Boolean(state),
-      });
-    } catch (error) {
-      this.log.error(String(error));
-    }
-  };
-
-  getTargetTemperature = async () => {
-    return this._device.state$.value.targetTemperature;
-  };
-
-  setTargetTemperature = async (state: any) => {
-    try {
-      await this._device.changeState({
-        targetTemperature: state,
-      });
-    } catch (error) {
-      this.log.error(String(error));
-    }
-  };
-
-  getSwingMode = async () => {
-    const { power, limits } = this._device.state$.value;
-
-    if (limits === Limits.ONLY_VERTICAL && power) {
-      return this._api.hap.Characteristic.SwingMode.SWING_ENABLED;
-    }
-
-    return this._api.hap.Characteristic.SwingMode.SWING_DISABLED;
-  };
-
-  setSwingMode = async (state: any) => {
-    const limits =
-      state === this._api.hap.Characteristic.SwingMode.SWING_ENABLED
-        ? Limits.ONLY_VERTICAL
-        : Limits.OFF;
-    try {
-      await this._device.changeState({ limits });
-    } catch (error) {
-      this.log.error(String(error));
-    }
-  };
-
-  getRotationSpeed = async () => {
-    const { fanSpeed } = this._device.state$.value;
-
-    switch (fanSpeed) {
+  protected getRotationSpeed = (): CharacteristicValue => {
+    switch (this.device.state$.value.fanSpeed) {
       case FanSpeed.MIN:
-        return 1;
+        return 33;
       case FanSpeed.MID:
-        return 2;
+        return 66;
       case FanSpeed.MAX:
-        return 3;
+        return 100;
       default:
       case FanSpeed.AUTO:
-        return 0;
+        return 0; // 0% represents automatic fan speed
     }
   };
 
-  setRotationSpeed = async (state: any) => {
-    const { mode } = this._device.state$.value;
+  protected getSwingMode = (): CharacteristicValue => {
+    const { SwingMode } = this.api.hap.Characteristic;
+    const { power, limits } = this.device.state$.value;
 
-    let fanSpeed = FanSpeed.AUTO;
+    return power && limits === Limits.ONLY_VERTICAL
+      ? SwingMode.SWING_ENABLED
+      : SwingMode.SWING_DISABLED;
+  };
 
-    if (state > 0 || (state === 0 && mode === Mode.FAN)) {
-      fanSpeed = FanSpeed.MIN;
+  protected getHealth = (): CharacteristicValue => {
+    return this.device.state$.value.health;
+  };
+
+  // ---- setters ----
+
+  protected setActive = async (value: CharacteristicValue) => {
+    const { Active } = this.api.hap.Characteristic;
+    try {
+      if (value === Active.ACTIVE) {
+        if (!this.device.state$.value.power) await this.device.on();
+      } else if (this.device.state$.value.power) {
+        await this.device.off();
+      }
+    } catch (error) {
+      this.log.error(String(error));
     }
+  };
 
-    if (state > 1) {
-      fanSpeed = FanSpeed.MID;
-    }
-
-    if (state > 2) {
-      fanSpeed = FanSpeed.MAX;
-    }
+  protected setTargetHeaterCoolerState = async (value: CharacteristicValue) => {
+    const { TargetHeaterCoolerState } = this.api.hap.Characteristic;
+    let mode = this.autoMode;
+    if (value === TargetHeaterCoolerState.HEAT) mode = Mode.HEAT;
+    else if (value === TargetHeaterCoolerState.COOL) mode = Mode.COOL;
 
     try {
-      await this._device.changeState({ fanSpeed });
+      if (this.device.state$.value.mode !== mode) {
+        await this.device.changeState({ mode });
+      }
+    } catch (error) {
+      this.log.error(String(error));
+    }
+  };
+
+  protected setTargetTemperature = async (value: CharacteristicValue) => {
+    try {
+      await this.device.changeState({ targetTemperature: Number(value) });
+    } catch (error) {
+      this.log.error(String(error));
+    }
+  };
+
+  protected setRotationSpeed = async (value: CharacteristicValue) => {
+    const speed = Number(value);
+    let fanSpeed = FanSpeed.AUTO;
+    if (speed > 0 && speed <= 33) fanSpeed = FanSpeed.MIN;
+    else if (speed > 33 && speed <= 66) fanSpeed = FanSpeed.MID;
+    else if (speed > 66) fanSpeed = FanSpeed.MAX;
+
+    try {
+      await this.device.changeState({ fanSpeed });
+    } catch (error) {
+      this.log.error(String(error));
+    }
+  };
+
+  protected setSwingMode = async (value: CharacteristicValue) => {
+    const { SwingMode } = this.api.hap.Characteristic;
+    const limits = value === SwingMode.SWING_ENABLED ? Limits.ONLY_VERTICAL : Limits.OFF;
+    try {
+      await this.device.changeState({ limits });
+    } catch (error) {
+      this.log.error(String(error));
+    }
+  };
+
+  protected setHealth = async (value: CharacteristicValue) => {
+    try {
+      await this.device.changeState({ health: Boolean(value) });
     } catch (error) {
       this.log.error(String(error));
     }


### PR DESCRIPTION
Reworks how the Haier AC is presented in HomeKit and targets modern Homebridge. **homebridge-haier-ac only** — the core lib is untouched.

## What changes in the Home app
Replaces the old **Thermostat + Fanv2 + Lightbulb** trio with a single native **HeaterCooler** accessory (+ a small switch):

| HomeKit control | Maps to |
| --- | --- |
| On / Off (`Active`) | power |
| Mode `AUTO` / `HEAT` / `COOL` | `treatAutoHeatAs` (smart/fan) / heat / cool |
| Current temperature | AC sensor |
| Target temperature (cooling/heating threshold) | 16–30 °C |
| Fan speed | `0%` = **auto**, then low / medium / high |
| Swing | vertical louver |
| **Health** switch | ionizer / health (was a Lightbulb 🙄) |

Physical-remote changes are pushed back into every characteristic.

## Why
- `Thermostat` is semantically a heating device; `HeaterCooler` is the native AC service.
- Fan speed was exposed as `0–3`; now it's a proper percentage, and `0%` gives access to the AC's **auto** fan without an extra switch (on/off lives on `Active`).
- The ionizer as a **Lightbulb** was a hack → now an honest **Switch**.

## Modern Homebridge
- devDep `homebridge` → **^2.2.1**; `engines`: node `>=18`, homebridge `>=1.6.0`.
- Uses the promise-based `onGet`/`onSet` API throughout (no legacy event callbacks).

## Verification
- `npm run build` / `typecheck` (against HB 2.2.1 types) / `test` / `format:check` — all green.
- Integration-checked against a real AC: the accessory constructs with real `hap-nodejs` and all characteristic getters map device state correctly. The write path delegates to `device.changeState/on/off`, verified live in earlier testing.

## Notes
- ⚠️ Breaking: raises `engines` (old Homebridge/Node dropped) and the HomeKit accessory is re-created — the tile and any automations referencing the old Thermostat/Fan may need reassigning.
- Kept as an **accessory** plugin (not converted to a dynamic platform) to avoid breaking users' `config.json` format.
- Bump `homebridge-haier-ac` 0.3.0 → **0.4.0**.

Follow-up (separate, in core): `HaierAC._sendRequest` calls `this._connect()` on timeout without handling its rejection → surfaces as an unhandledRejection when the device is unreachable.