### PR TITLE
fix(core): avoid unhandledRejection on reconnect when device is unreachable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2726,7 +2726,7 @@
       }
     },
     "packages/haier-ac-remote": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "binary-parser": "^2.3.0",
@@ -2737,7 +2737,7 @@
       }
     },
     "packages/homebridge-haier-ac": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "haier-ac-remote": "^0.2.0"
@@ -2746,8 +2746,8 @@
         "homebridge": "^2.2.1"
       },
       "engines": {
-        "homebridge": ">=1.3.0",
-        "node": ">=12.0.0"
+        "homebridge": ">=1.6.0",
+        "node": ">=18.0.0"
       }
     }
   }

--- a/packages/haier-ac-remote/package.json
+++ b/packages/haier-ac-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haier-ac-remote",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A node module remote controller for Haier air conditioner",
   "keywords": [
     "haier",

--- a/packages/haier-ac-remote/src/HaierAC.ts
+++ b/packages/haier-ac-remote/src/HaierAC.ts
@@ -107,7 +107,7 @@ export class HaierAC {
     });
     this._client.on('close', (err) => {
       if (!err) {
-        this._connect();
+        this._connect().catch(logError);
       }
 
       logError('Connection closed>>>');
@@ -194,7 +194,7 @@ export class HaierAC {
     send(this._client, cmd);
 
     return firstValueFrom(o$).catch(() => {
-      this._connect();
+      this._connect().catch(logError);
 
       return false;
     });


### PR DESCRIPTION
`haier-ac-remote` only.

## Problem
`HaierAC` fires a reconnect via `_connect()` in two fire-and-forget spots — on request timeout (inside `_sendRequest`) and on socket `close`. `_connect()` rejects with `'connection timeout error'` when the device can't be reached, and that rejection was **unhandled**, crashing the host process.

Observed live: when the AC dropped off the network mid-test, a command triggered
`UnhandledPromiseRejection ... "connection timeout error"`.

## Fix
Attach `.catch(logError)` to both fire-and-forget `_connect()` calls (the constructor's initial connect was already handled).

## Verification
- Repro against an unreachable host (`192.0.2.1`, TEST-NET-1) with an `unhandledRejection` detector: **PASS — no unhandledRejection** (before the fix it crashed).
- `npm run build` / `typecheck` / `test` (3/3) / `format:check` — all green.

Bump `haier-ac-remote` 0.2.0 → **0.2.1** (patch). `homebridge-haier-ac` depends on `^0.2.0`, so no dependency change needed.